### PR TITLE
Improve interoperability between CKRefreshControl and UIRefreshControl classes

### DIFF
--- a/CKRefreshControl/CKParagraphStyle.m
+++ b/CKRefreshControl/CKParagraphStyle.m
@@ -44,52 +44,13 @@
     // CKParagraphStyle will masquerade as NSParagraphStyle
     static dispatch_once_t registerNSParagraphStyleClass_onceToken;
     dispatch_once(&registerNSParagraphStyleClass_onceToken, ^{
-        
-        Class *NSParagraphStyleClassRef = NULL;
-#if TARGET_CPU_ARM
-        __asm(
-              "movw %0, :lower16:(L_OBJC_CLASS_NSParagraphStyle-(LPC0+4))\n"
-              "movt %0, :upper16:(L_OBJC_CLASS_NSParagraphStyle-(LPC0+4))\n"
-              "LPC0: add %0, pc" : "=r"(NSParagraphStyleClassRef)
-              );
-#elif TARGET_CPU_X86_64
-        __asm("leaq L_OBJC_CLASS_NSParagraphStyle(%%rip), %0" : "=r"(NSParagraphStyleClassRef));
-#elif TARGET_CPU_X86
-        void *pc = NULL;
-        __asm(
-              "calll L0\n"
-              "L0: popl %0\n"
-              "leal L_OBJC_CLASS_NSParagraphStyle-L0(%0), %1" : "=r"(pc), "=r"(NSParagraphStyleClassRef)
-              );
-#else
-#error Unsupported CPU
-#endif
-        if (NSParagraphStyleClassRef && *NSParagraphStyleClassRef == Nil)
-            *NSParagraphStyleClassRef = objc_duplicateClass(self, "NSParagraphStyle", 0);
+        Class nsParagraphStyleClass = NSClassFromString(@"NSParagraphStyle");
+        if (!nsParagraphStyleClass)
+        {
+            nsParagraphStyleClass = objc_allocateClassPair(self, "NSParagraphStyle", 0);
+            objc_registerClassPair(nsParagraphStyleClass);
+        }
     });
 }
-__asm(
-#if defined(__OBJC2__) && __OBJC2__
-      ".section        __DATA,__objc_classrefs,regular,no_dead_strip\n"
-#if	TARGET_RT_64_BIT
-      ".align          3\n"
-      "L_OBJC_CLASS_NSParagraphStyle:\n"
-      ".quad           _OBJC_CLASS_$_NSParagraphStyle\n"
-#else
-      ".align          2\n"
-      "L_OBJC_CLASS_NSParagraphStyle:\n"
-      ".long           _OBJC_CLASS_$_NSParagraphStyle\n"
-#endif
-#else
-      ".section        __TEXT,__cstring,cstring_literals\n"
-      "L_OBJC_CLASS_NAME_NSParagraphStyle:\n"
-      ".asciz          \"NSParagraphStyle\"\n"
-      ".section        __OBJC,__cls_refs,literal_pointers,no_dead_strip\n"
-      ".align          2\n"
-      "L_OBJC_CLASS_NSParagraphStyle:\n"
-      ".long           L_OBJC_CLASS_NAME_NSParagraphStyle\n"
-#endif
-      ".weak_reference _OBJC_CLASS_$_NSParagraphStyle\n"
-      );
                   
 @end

--- a/CKRefreshControl/CKParagraphStyle.m
+++ b/CKRefreshControl/CKParagraphStyle.m
@@ -31,8 +31,6 @@
 #define IMP_WITH_BLOCK_TYPE id
 #endif
 
-static void *NSParagraphStyleKey;
-
 - (id) initWithCoder: (NSCoder *) aDecoder
 {
     return [super init];
@@ -67,26 +65,7 @@ static void *NSParagraphStyleKey;
 #error Unsupported CPU
 #endif
         if (NSParagraphStyleClassRef && *NSParagraphStyleClassRef == Nil)
-        {
             *NSParagraphStyleClassRef = objc_duplicateClass(self, "NSParagraphStyle", 0);
-        }
-        
-        Class nsAttributedStringClass = [NSAttributedString class];
-        IMP paragraphStyleIMP = imp_implementationWithBlock((IMP_WITH_BLOCK_TYPE)(^NSParagraphStyle *(id dynamicSelf) {
-            return objc_getAssociatedObject(dynamicSelf, &NSParagraphStyleKey);
-        }));
-        BOOL added = class_addMethod(nsAttributedStringClass, @selector(paragraphStyle), paragraphStyleIMP, "@@:");
-        NSAssert(added, @"We tried to add the paragraphStyle method, and it failed. This is going to break things, so we may as well stop here.");
-        
-        IMP setParagraphStyleIMP = imp_implementationWithBlock((IMP_WITH_BLOCK_TYPE)(^void(NSAttributedString *dynamicSelf, id paragraphStyle) {
-            if (dynamicSelf.paragraphStyle == paragraphStyle) {
-                return;
-            }
-            objc_setAssociatedObject(dynamicSelf, &NSParagraphStyleKey, paragraphStyle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        }));
-        
-        added = class_addMethod(nsAttributedStringClass, @selector(setParagraphStyle:), setParagraphStyleIMP, "v@:@");
-        NSAssert(added, @"We tried to add the setParagraphStyle: method, and it failed. This is going to break things, so we may as well stop here.");
     });
 }
 __asm(

--- a/CKRefreshControl/CKParagraphStyle.m
+++ b/CKRefreshControl/CKParagraphStyle.m
@@ -23,8 +23,6 @@
 #import "CKParagraphStyle.h"
 #import <objc/objc-runtime.h>
 
-static BOOL _isMasquerading = NO;
-
 @implementation CKParagraphStyle
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED <= __IPHONE_5_1
@@ -48,9 +46,30 @@ static void *NSParagraphStyleKey;
     // CKParagraphStyle will masquerade as NSParagraphStyle
     static dispatch_once_t registerNSParagraphStyleClass_onceToken;
     dispatch_once(&registerNSParagraphStyleClass_onceToken, ^{
-        Class nsParagraphStyleClass = objc_allocateClassPair([self class], "NSParagraphStyle", 0);
-        objc_registerClassPair(nsParagraphStyleClass);
-        _isMasquerading = YES;
+        
+        Class *NSParagraphStyleClassRef = NULL;
+#if TARGET_CPU_ARM
+        __asm(
+              "movw %0, :lower16:(L_OBJC_CLASS_NSParagraphStyle-(LPC0+4))\n"
+              "movt %0, :upper16:(L_OBJC_CLASS_NSParagraphStyle-(LPC0+4))\n"
+              "LPC0: add %0, pc" : "=r"(NSParagraphStyleClassRef)
+              );
+#elif TARGET_CPU_X86_64
+        __asm("leaq L_OBJC_CLASS_NSParagraphStyle(%%rip), %0" : "=r"(NSParagraphStyleClassRef));
+#elif TARGET_CPU_X86
+        void *pc = NULL;
+        __asm(
+              "calll L0\n"
+              "L0: popl %0\n"
+              "leal L_OBJC_CLASS_NSParagraphStyle-L0(%0), %1" : "=r"(pc), "=r"(NSParagraphStyleClassRef)
+              );
+#else
+#error Unsupported CPU
+#endif
+        if (NSParagraphStyleClassRef && *NSParagraphStyleClassRef == Nil)
+        {
+            *NSParagraphStyleClassRef = objc_duplicateClass(self, "NSParagraphStyle", 0);
+        }
         
         Class nsAttributedStringClass = [NSAttributedString class];
         IMP paragraphStyleIMP = imp_implementationWithBlock((IMP_WITH_BLOCK_TYPE)(^NSParagraphStyle *(id dynamicSelf) {
@@ -70,5 +89,28 @@ static void *NSParagraphStyleKey;
         NSAssert(added, @"We tried to add the setParagraphStyle: method, and it failed. This is going to break things, so we may as well stop here.");
     });
 }
+__asm(
+#if defined(__OBJC2__) && __OBJC2__
+      ".section        __DATA,__objc_classrefs,regular,no_dead_strip\n"
+#if	TARGET_RT_64_BIT
+      ".align          3\n"
+      "L_OBJC_CLASS_NSParagraphStyle:\n"
+      ".quad           _OBJC_CLASS_$_NSParagraphStyle\n"
+#else
+      ".align          2\n"
+      "L_OBJC_CLASS_NSParagraphStyle:\n"
+      ".long           _OBJC_CLASS_$_NSParagraphStyle\n"
+#endif
+#else
+      ".section        __TEXT,__cstring,cstring_literals\n"
+      "L_OBJC_CLASS_NAME_NSParagraphStyle:\n"
+      ".asciz          \"NSParagraphStyle\"\n"
+      ".section        __OBJC,__cls_refs,literal_pointers,no_dead_strip\n"
+      ".align          2\n"
+      "L_OBJC_CLASS_NSParagraphStyle:\n"
+      ".long           L_OBJC_CLASS_NAME_NSParagraphStyle\n"
+#endif
+      ".weak_reference _OBJC_CLASS_$_NSParagraphStyle\n"
+      );
                   
 @end

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -36,8 +36,6 @@ typedef enum {
     CKRefreshControlStateRefreshing
 } CKRefreshControlState;
 
-static BOOL _isMasquerading = NO;
-
 @interface CKRefreshControl ()
 @property (nonatomic) CKRefreshControlState refreshControlState;
 @end

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -371,6 +371,9 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
     if (![uiRefreshControlClass isSubclassOfClass:[CKRefreshControl class]])
         return [UIRefreshControl appearance];
     
+    if ([self isEqual:[UIRefreshControl class]])
+        return [CKRefreshControl appearance];
+
     return [super appearance];
 }
 

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -82,6 +82,13 @@ static BOOL _isMasquerading = NO;
     return self;
 }
 
+- (void) commonInit
+{
+    self.frame = CGRectMake(0, 0, 320, 60);
+    [self populateSubviews];
+    [self setRefreshControlState:CKRefreshControlStateHidden];
+}
+
 - (void) tableViewControllerDidSetView: (NSNotification *) notification
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self
@@ -91,13 +98,6 @@ static BOOL _isMasquerading = NO;
     UITableViewController *tableViewController = notification.object;
     if (tableViewController.refreshControl != (id)self)
         tableViewController.refreshControl = (id)self;
-}
-
-- (void) commonInit
-{
-    self.frame = CGRectMake(0, 0, 320, 60);
-    [self populateSubviews];
-    [self setRefreshControlState:CKRefreshControlStateHidden];
 }
 
 // remove notification observer in case notification never fired
@@ -358,7 +358,6 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
     }
 }
 
-
 #if __IPHONE_OS_VERSION_MAX_ALLOWED <= __IPHONE_5_1
 #define IMP_WITH_BLOCK_TYPE __bridge void*
 #else
@@ -427,9 +426,7 @@ static void CKRefreshControl_UITableViewController_SetView(UITableViewController
 #error Unsupported CPU
 #endif
         if (UIRefreshControlClassRef && *UIRefreshControlClassRef == Nil)
-        {
             *UIRefreshControlClassRef = objc_duplicateClass(self, "UIRefreshControl", 0);
-        }
         
         // Add UITableViewController.refreshControl if it isn't present
         Class tableViewController = [UITableViewController class];

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -50,10 +50,12 @@ typedef enum {
 
 - (id)init
 {
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
-    if (![uiRefreshControlClass isSubclassOfClass:[CKRefreshControl class]])
+    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
+    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
+
+    if (![uiRefreshControlClass isSubclassOfClass:ckRefreshControlClass])
         return (id)[[UIRefreshControl alloc] init];
-    
+
     if (self = [super init])
     {
         [self commonInit];
@@ -362,16 +364,31 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
 
 #pragma mark - Class methods
 
++ (Class) class
+{
+    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
+    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
+    
+    if (![self isSubclassOfClass:ckRefreshControlClass])
+        return uiRefreshControlClass;
+
+    if ([self isEqual:uiRefreshControlClass])
+        return ckRefreshControlClass;
+
+    return [super class];
+}
+
 // If UIRefreshControl is available, we need to customize that class, not
 // CKRefreshControl. Otherwise, the +appearance proxy is broken on iOS 6.
 + (id)appearance
 {
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
+    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
+    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
 
-    if (![uiRefreshControlClass isSubclassOfClass:[CKRefreshControl class]])
+    if (![uiRefreshControlClass isSubclassOfClass:ckRefreshControlClass])
         return [UIRefreshControl appearance];
-    
-    if ([self isEqual:[UIRefreshControl class]])
+
+    if ([self isEqual:uiRefreshControlClass])
         return [CKRefreshControl appearance];
 
     return [super appearance];
@@ -393,12 +410,13 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
     }
     va_end(list);
     
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
+    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
+    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
     
-    if (![uiRefreshControlClass isSubclassOfClass:[CKRefreshControl class]])
+    if (![uiRefreshControlClass isSubclassOfClass:ckRefreshControlClass])
         return [UIRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 
-    if ([self isEqual:[UIRefreshControl class]])
+    if ([self isEqual:uiRefreshControlClass])
         return [CKRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 
     return [super appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -50,10 +50,7 @@ typedef enum {
 
 - (id)init
 {
-    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
-    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
-
-    if (![uiRefreshControlClass isSubclassOfClass:ckRefreshControlClass])
+    if (![[UIRefreshControl class] isSubclassOfClass:[CKRefreshControl class]])
         return (id)[[UIRefreshControl alloc] init];
 
     if (self = [super init])
@@ -366,14 +363,12 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
 
 + (Class) class
 {
-    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
-    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
+    // cannot call +class from inside this method
+    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
+    Class ckRefreshControlClass = NSClassFromString(@"CKRefreshControl");
     
     if (![self isSubclassOfClass:ckRefreshControlClass])
         return uiRefreshControlClass;
-
-    if ([self isEqual:uiRefreshControlClass])
-        return ckRefreshControlClass;
 
     return [super class];
 }
@@ -382,13 +377,10 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
 // CKRefreshControl. Otherwise, the +appearance proxy is broken on iOS 6.
 + (id)appearance
 {
-    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
-    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
-
-    if (![uiRefreshControlClass isSubclassOfClass:ckRefreshControlClass])
+    if (![[UIRefreshControl class] isSubclassOfClass:[CKRefreshControl class]])
         return [UIRefreshControl appearance];
 
-    if ([self isEqual:uiRefreshControlClass])
+    if ([self isEqual:[UIRefreshControl class]])
         return [CKRefreshControl appearance];
 
     return [super appearance];
@@ -409,14 +401,11 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
         classes[i] = c;
     }
     va_end(list);
-    
-    Class uiRefreshControlClass = objc_getClass("UIRefreshControl");
-    Class ckRefreshControlClass = objc_getClass("CKRefreshControl");
-    
-    if (![uiRefreshControlClass isSubclassOfClass:ckRefreshControlClass])
+
+    if (![[UIRefreshControl class] isSubclassOfClass:[CKRefreshControl class]])
         return [UIRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 
-    if ([self isEqual:uiRefreshControlClass])
+    if ([self isEqual:[UIRefreshControl class]])
         return [CKRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 
     return [super appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -52,11 +52,6 @@ static BOOL _isMasquerading = NO;
 
 - (id)init
 {
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
-    
-    if (uiRefreshControlClass && !_isMasquerading)
-        return [[uiRefreshControlClass alloc] init];
-
     if (self = [super init])
     {
         [self commonInit];
@@ -79,16 +74,23 @@ static BOOL _isMasquerading = NO;
             self.attributedTitle = [aDecoder decodeObjectForKey:@"UIAttributedTitle"];
 
         // we can set its refresh control when the table view controller sets its view
-        [[NSNotificationCenter defaultCenter] addObserverForName: CKRefreshControl_UITableViewController_DidSetView_Notification
-                                                          object: nil
-                                                           queue: nil
-                                                      usingBlock: ^(NSNotification *notification) {
-                                                          UITableViewController *tableViewController = notification.object;
-                                                          if (tableViewController.refreshControl != (id)self)
-                                                              tableViewController.refreshControl = (id)self;
-                                                      }                                                                             ];
+        [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(tableViewControllerDidSetView:)
+                                                     name: CKRefreshControl_UITableViewController_DidSetView_Notification
+                                                   object: nil                                                              ];
     }
     return self;
+}
+
+- (void) tableViewControllerDidSetView: (NSNotification *) notification
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:CKRefreshControl_UITableViewController_DidSetView_Notification
+                                                  object:nil];
+
+    UITableViewController *tableViewController = notification.object;
+    if (tableViewController.refreshControl != (id)self)
+        tableViewController.refreshControl = (id)self;
 }
 
 - (void) commonInit
@@ -101,7 +103,9 @@ static BOOL _isMasquerading = NO;
 // remove notification observer in case notification never fired
 - (void) awakeFromNib
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:CKRefreshControl_UITableViewController_DidSetView_Notification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver: self
+                                                    name: CKRefreshControl_UITableViewController_DidSetView_Notification
+                                                  object: nil                                                           ];
     [super awakeFromNib];
 }
 
@@ -131,10 +135,11 @@ static BOOL _isMasquerading = NO;
     [self addSubview:spinner];
 }
 
-- (void)setTintColor:(UIColor *)tintColor {
-    if (tintColor == nil) {
-        tintColor = [UIColor colorWithWhite:0.5 alpha:1];
-    }
+- (void)setTintColor: (UIColor *) tintColor
+{
+    if (!tintColor)
+        return;
+
     textLabel.textColor = tintColor;
     arrow.tintColor = tintColor;
     spinner.color = tintColor;
@@ -353,56 +358,6 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
     }
 }
 
-#pragma mark - Class methods
-
-// If UIRefreshControl is available, we need to customize that class, not
-// CKRefreshControl. Otherwise, the +appearance proxy is broken on iOS 6.
-+ (id)appearance {
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
-    if (uiRefreshControlClass) {
-        return [UIRefreshControl appearance];
-    }
-    else {
-        return [super appearance];
-    }
-}
-
-+ (id)appearanceWhenContainedIn:(Class<UIAppearanceContainer>)ContainerClass, ... {
-    
-    va_list list;
-    va_start(list, ContainerClass);
-    
-    Class classes[10] = {0};
-    
-    for (int i=0; i<10; ++i) {
-        Class c = va_arg(list, Class);
-        if (c == Nil) {
-            break;
-        }
-        classes[i] = c;
-    }
-    va_end(list);
-    
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
-    if (uiRefreshControlClass) {
-        return [UIRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
-    } else {
-        return [super appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
-    }
-}
-
-// This is overridden so that things like
-//    [control isKindOfClass:[CKRefreshControl class]]
-// will work on both iOS 5 and iOS 6.
-+ (Class)class {
-    Class uiRefreshControlClass = NSClassFromString(@"UIRefreshControl");
-
-    if (uiRefreshControlClass)
-        return uiRefreshControlClass;
-
-    return [super class];
-}
-
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED <= __IPHONE_5_1
 #define IMP_WITH_BLOCK_TYPE __bridge void*
@@ -451,10 +406,31 @@ static void CKRefreshControl_UITableViewController_SetView(UITableViewController
     // CKRefreshControl will masquerade as UIRefreshControl
     static dispatch_once_t registerUIRefreshControlClass_onceToken;
     dispatch_once(&registerUIRefreshControlClass_onceToken, ^{
-        Class uiRefreshControlClass = objc_allocateClassPair([self class], "UIRefreshControl", 0);
-        objc_registerClassPair(uiRefreshControlClass);
-        _isMasquerading = YES;
 
+        Class *UIRefreshControlClassRef = NULL;
+#if TARGET_CPU_ARM
+        __asm(
+              "movw %0, :lower16:(L_OBJC_CLASS_UIRefreshControl-(LPC0+4))\n"
+              "movt %0, :upper16:(L_OBJC_CLASS_UIRefreshControl-(LPC0+4))\n"
+              "LPC0: add %0, pc" : "=r"(UIRefreshControlClassRef)
+              );
+#elif TARGET_CPU_X86_64
+        __asm("leaq L_OBJC_CLASS_UIRefreshControl(%%rip), %0" : "=r"(UIRefreshControlClassRef));
+#elif TARGET_CPU_X86
+        void *pc = NULL;
+        __asm(
+              "calll L0\n"
+              "L0: popl %0\n"
+              "leal L_OBJC_CLASS_UIRefreshControl-L0(%0), %1" : "=r"(pc), "=r"(UIRefreshControlClassRef)
+              );
+#else
+#error Unsupported CPU
+#endif
+        if (UIRefreshControlClassRef && *UIRefreshControlClassRef == Nil)
+        {
+            *UIRefreshControlClassRef = objc_duplicateClass(self, "UIRefreshControl", 0);
+        }
+        
         // Add UITableViewController.refreshControl if it isn't present
         Class tableViewController = [UITableViewController class];
         IMP refreshControlIMP = imp_implementationWithBlock((IMP_WITH_BLOCK_TYPE)(^id(id dynamicSelf) {
@@ -487,5 +463,29 @@ static void CKRefreshControl_UITableViewController_SetView(UITableViewController
                                     (IMP *)&UITableViewController_SetViewIMP            );
     });
 }
+
+__asm(
+#if defined(__OBJC2__) && __OBJC2__
+      ".section        __DATA,__objc_classrefs,regular,no_dead_strip\n"
+#if	TARGET_RT_64_BIT
+      ".align          3\n"
+      "L_OBJC_CLASS_UIRefreshControl:\n"
+      ".quad           _OBJC_CLASS_$_UIRefreshControl\n"
+#else
+      ".align          2\n"
+      "L_OBJC_CLASS_UIRefreshControl:\n"
+      ".long           _OBJC_CLASS_$_UIRefreshControl\n"
+#endif
+#else
+      ".section        __TEXT,__cstring,cstring_literals\n"
+      "L_OBJC_CLASS_NAME_UIRefreshControl:\n"
+      ".asciz          \"UIRefreshControl\"\n"
+      ".section        __OBJC,__cls_refs,literal_pointers,no_dead_strip\n"
+      ".align          2\n"
+      "L_OBJC_CLASS_UIRefreshControl:\n"
+      ".long           L_OBJC_CLASS_NAME_UIRefreshControl\n"
+#endif
+      ".weak_reference _OBJC_CLASS_$_UIRefreshControl\n"
+      );
 
 @end

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -140,7 +140,7 @@ typedef enum {
 - (void)setTintColor: (UIColor *) tintColor
 {
     if (!tintColor)
-        return;
+        tintColor = [UIColor colorWithWhite:0.5 alpha:1];
 
     textLabel.textColor = tintColor;
     arrow.tintColor = tintColor;

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -395,6 +395,9 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
     if (![uiRefreshControlClass isSubclassOfClass:[CKRefreshControl class]])
         return [UIRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 
+    if ([self isEqual:[UIRefreshControl class]])
+        return [CKRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
+
     return [super appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 }
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Yes! Instructure is using it in shipping code with no problems. That said, if yo
 
 --- 
 
-### Contributor
+### Contributors
 
 * [@bjhomer](http://github.com/bjhomer)
 * [@johnhaitas](http://github.com/johnhaitas)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Yes! Instructure is using it in shipping code with no problems. That said, if yo
 
 --- 
 
+### Contributor
+
+* [@bjhomer](http://github.com/bjhomer)
+* [@johnhaitas](http://github.com/johnhaitas)
+* [@steipete](http://github.com/steipete)
+* [@0xced](http://github.com/0xced)
+
+---
+
 ### License
 
 CKRefreshControl, and all the accompanying source code, is released under the MIT license. You can see the full text of the license in the accompanying LICENSE.txt file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CKRefreshControl
 
-Open source 100% API-compatible replacement for `UIRefreshControl`, supporting iOS 5.0+
+Open source 100% API-compatible replacement for [UIRefreshControl](http://developer.apple.com/library/ios/#documentation/uikit/reference/UIRefreshControl_class/Reference/Reference.html) , supporting iOS 5.0+
 
 Using it is as simple as this:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then just link against the static library the `CKRefreshControl` project provide
 
 ### API Compatible
 
-CKRefreshControl has exactly the same public API as UIRefreshControl. Thus, your code can treat either one as an instance of the other. Just use CKRefreshControl or UIRefreshControl throughout your code, and you'll magically get iOS 5 support.
+CKRefreshControl has exactly the same public API as UIRefreshControl. Thus, your code can treat either one as an instance of the other. Just use `CKRefreshControl` or `UIRefreshControl` throughout your code, and you'll magically get iOS 5 support.
 
 We take advantage of this to provide excellent iOS 6 compatibility. When running on an iOS 6 device, `-[CKRefreshControl init]` actually returns a `UIRefreshControl` instance. No CKRefreshControl is ever initialized, and everything will work exactly as if CKRefreshControl did not even exist.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Using it is as simple as this:
 
     UITableViewController *controller;
 
-    CKRefreshControl *refreshControl = [CKRefreshControl new];
-    [refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
-    controller.refreshControl = (id)refreshControl;
+    controller.refreshControl = [[UIRefreshControl alloc] init];
+    [controller.refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
 
 Then just link against the static library the `CKRefreshControl` project provides, and you're ready to go.
 
@@ -21,13 +20,11 @@ Then just link against the static library the `CKRefreshControl` project provide
 
 ### API Compatible
 
-CKRefreshControl has exactly the same public API as UIRefreshControl. Thus, your code can treat either one as an instance of the other. Just use CKRefreshControl instead of UIRefreshControl everywhere, and you'll magically get iOS 5 support.
+CKRefreshControl has exactly the same public API as UIRefreshControl. Thus, your code can treat either one as an instance of the other. Just use CKRefreshControl or UIRefreshControl throughout your code, and you'll magically get iOS 5 support.
 
 We take advantage of this to provide excellent iOS 6 compatibility. When running on an iOS 6 device, `-[CKRefreshControl init]` actually returns a `UIRefreshControl` instance. No CKRefreshControl is ever initialized, and everything will work exactly as if CKRefreshControl did not even exist.
 
 You can even use the `+appearance` proxies introduced in iOS 5.0; CKRefreshControl will appropriately forward the customizations to UIRefreshControl on iOS 6.
-
-There is only one minor inconvenience. The `-[UITableViewController setRefreshControl:]` method in iOS 6 accepts a `UIRefreshControl *` parameter. Although CKRefreshControl is API compatible with UIRefreshControl, it is not a subclass (so it can be used on iOS 5). Thus, the compiler does not know that CKRefreshControl can be used as a UIRefreshControl. Thus, you must add an explicit cast to avoid a compiler warning. This is completely safe.
 
 ---
 

--- a/RefreshControlDemo/AppDelegate.m
+++ b/RefreshControlDemo/AppDelegate.m
@@ -30,7 +30,7 @@
 {
     application.statusBarStyle = UIStatusBarStyleBlackOpaque;
     
-    [[CKRefreshControl appearanceWhenContainedIn:[AppearanceCustomizationController class], [UITabBarController class], nil] setTintColor:[UIColor greenColor]];
+    [[CKRefreshControl appearanceWhenContainedIn:[AppearanceCustomizationController class], nil] setTintColor:[UIColor greenColor]];
     
     // Override point for customization after application launch.
     return YES;

--- a/RefreshControlDemo/AppDelegate.m
+++ b/RefreshControlDemo/AppDelegate.m
@@ -30,7 +30,7 @@
 {
     application.statusBarStyle = UIStatusBarStyleBlackOpaque;
     
-    [[CKRefreshControl appearanceWhenContainedIn:[AppearanceCustomizationController class], nil] setTintColor:[UIColor greenColor]];
+    [[UIRefreshControl appearanceWhenContainedIn:[AppearanceCustomizationController class], nil] setTintColor:[UIColor greenColor]];
     
     // Override point for customization after application launch.
     return YES;

--- a/RefreshControlDemo/AppearanceCustomizationController.m
+++ b/RefreshControlDemo/AppearanceCustomizationController.m
@@ -29,9 +29,8 @@
 {
     [super viewDidLoad];
     
-    CKRefreshControl *refreshControl = [CKRefreshControl new];
-    [refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
-    self.refreshControl = (id)refreshControl;
+    self.refreshControl = (id)[[CKRefreshControl alloc] init];
+    [self.refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
 }
 
 - (void)doRefresh:(CKRefreshControl *)sender {

--- a/RefreshControlDemo/AppearanceCustomizationController.m
+++ b/RefreshControlDemo/AppearanceCustomizationController.m
@@ -29,7 +29,7 @@
 {
     [super viewDidLoad];
     
-    self.refreshControl = (id)[[CKRefreshControl alloc] init];
+    self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
 }
 

--- a/RefreshControlDemo/ColorRefreshController.m
+++ b/RefreshControlDemo/ColorRefreshController.m
@@ -39,10 +39,9 @@
     @"Black" : [UIColor blackColor],
     };
     
-    CKRefreshControl *refreshControl = [CKRefreshControl new];
-    refreshControl.tintColor = [UIColor orangeColor];
-    [refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
-    self.refreshControl = (id)refreshControl;
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    self.refreshControl.tintColor = [UIColor orangeColor];
+    [self.refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
 }
 
 - (void)doRefresh:(CKRefreshControl *)sender {

--- a/RefreshControlDemo/DefaultRefreshController.m
+++ b/RefreshControlDemo/DefaultRefreshController.m
@@ -29,9 +29,8 @@
 {
     [super viewDidLoad];
     
-    CKRefreshControl *refreshControl = [CKRefreshControl new];
-    [refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
-    self.refreshControl = (id)refreshControl;
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    [self.refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
 }
 
 - (void)doRefresh:(CKRefreshControl *)sender {

--- a/RefreshControlDemo/TextRefreshingController.m
+++ b/RefreshControlDemo/TextRefreshingController.m
@@ -32,11 +32,10 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    CKRefreshControl *refreshControl = [CKRefreshControl new];
-    refreshControl.attributedTitle = [[NSAttributedString alloc] initWithString:@"This is a test"];
-    [refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
-    self.refreshControl = (id)refreshControl;
+
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    self.refreshControl.attributedTitle = [[NSAttributedString alloc] initWithString:@"This is a test"];
+    [self.refreshControl addTarget:self action:@selector(doRefresh:) forControlEvents:UIControlEventValueChanged];
 }
 
 - (void)doRefresh:(CKRefreshControl *)sender {


### PR DESCRIPTION
`CKRefreshControl` and `UIRefreshControl` can now be used interchangeably throughout the app.

Adds support for `UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];` in iOS5.
