### PR TITLE
Storyboard refresh control loses tintColor fix

### DIFF
--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -44,10 +44,9 @@ typedef enum {
     UILabel *textLabel;
     UIActivityIndicatorView *spinner;
     CKRefreshArrowView *arrow;
+    UIColor *defaultTintColor;
     CGFloat originalTopContentInset;
     CGFloat decelerationStartOffset;
-
-    BOOL _ignoreFirstAppearanceProxy;
 }
 
 - (id)init
@@ -73,7 +72,7 @@ typedef enum {
         if ([aDecoder containsValueForKey:@"UITintColor"])
         {
             self.tintColor = (UIColor *)[aDecoder decodeObjectForKey:@"UITintColor"];
-            _ignoreFirstAppearanceProxy = YES;
+            defaultTintColor = self.tintColor;
         }
         
         if ([aDecoder containsValueForKey:@"UIAttributedTitle"])
@@ -84,6 +83,7 @@ typedef enum {
                                                  selector: @selector(tableViewControllerDidSetView:)
                                                      name: CKRefreshControl_UITableViewController_DidSetView_Notification
                                                    object: nil                                                              ];
+
     }
     return self;
 }
@@ -93,7 +93,7 @@ typedef enum {
     self.frame = CGRectMake(0, 0, 320, 60);
     [self populateSubviews];
     [self setRefreshControlState:CKRefreshControlStateHidden];
-    _ignoreFirstAppearanceProxy = NO;
+    defaultTintColor = [UIColor colorWithWhite:0.5 alpha:1];
 }
 
 - (void) tableViewControllerDidSetView: (NSNotification *) notification
@@ -144,21 +144,8 @@ typedef enum {
 
 - (void)setTintColor: (UIColor *) tintColor
 {
-    if (_ignoreFirstAppearanceProxy)
-    {
-        NSPredicate *appearanceProxyPredicate = [NSPredicate predicateWithBlock:^BOOL(NSString *stackSymbol,NSDictionary *bindings){
-            return ([stackSymbol rangeOfString:@"_UIAppearance"].location != NSNotFound);
-        }];
-        NSArray *_appearanceStackSymbols = [[NSThread callStackSymbols] filteredArrayUsingPredicate:appearanceProxyPredicate];
-        if (_appearanceStackSymbols.count > 0)
-        {
-            _ignoreFirstAppearanceProxy = NO;
-            return;
-        }
-    }
-
     if (!tintColor)
-        tintColor = [UIColor colorWithWhite:0.5 alpha:1];
+        tintColor = defaultTintColor;
 
     textLabel.textColor = tintColor;
     arrow.tintColor = tintColor;

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -71,7 +71,10 @@ typedef enum {
         [self commonInit];
         
         if ([aDecoder containsValueForKey:@"UITintColor"])
+        {
             self.tintColor = (UIColor *)[aDecoder decodeObjectForKey:@"UITintColor"];
+            _ignoreFirstAppearanceProxy = YES;
+        }
         
         if ([aDecoder containsValueForKey:@"UIAttributedTitle"])
             self.attributedTitle = [aDecoder decodeObjectForKey:@"UIAttributedTitle"];
@@ -81,8 +84,6 @@ typedef enum {
                                                  selector: @selector(tableViewControllerDidSetView:)
                                                      name: CKRefreshControl_UITableViewController_DidSetView_Notification
                                                    object: nil                                                              ];
-
-        _ignoreFirstAppearanceProxy = YES;
     }
     return self;
 }


### PR DESCRIPTION
This pull request is addressing [issue 11](https://github.com/instructure/CKRefreshControl/issues/11)

a setTintColor:nil message is passed to the refresh control after the storyboard view controller has loaded.
