### PR TITLE
Resolution to /issues/15

### DIFF
--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -242,10 +242,11 @@ typedef enum {
         scrollView = (UIScrollView *)self.superview;
     }
     
-    [UIView animateWithDuration:0.2 animations:^{
-        scrollView.contentInset = contentInset;
-        
-    }];
+    if(!UIEdgeInsetsEqualToEdgeInsets(scrollView.contentInset, contentInset)) {
+        [UIView animateWithDuration:0.2 animations:^{
+            scrollView.contentInset = contentInset;
+        }];
+    }
     
 }
 


### PR DESCRIPTION
Don't apply a content inset animation when there is no change, fixing rendering issue with UITableView section indexes.
