### PR TITLE
XCode 5 warnings

### DIFF
--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -413,7 +413,7 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
     va_end(list);
 
     if (![[UIRefreshControl class] isSubclassOfClass:[CKRefreshControl class]])
-        return [UIRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
+        return (id)[UIRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];
 
     if ([self isEqual:[UIRefreshControl class]])
         return [CKRefreshControl appearanceWhenContainedIn:ContainerClass, classes[0], classes[1], classes[2], classes[3], classes[4], classes[5], classes[6], classes[7], classes[8], classes[9], nil];

--- a/CKRefreshControl/CKRefreshControl.m
+++ b/CKRefreshControl/CKRefreshControl.m
@@ -388,7 +388,7 @@ static void *contentOffsetObservingKey = &contentOffsetObservingKey;
 + (id)appearance
 {
     if (![[UIRefreshControl class] isSubclassOfClass:[CKRefreshControl class]])
-        return [UIRefreshControl appearance];
+        return (id)[UIRefreshControl appearance];
 
     if ([self isEqual:[UIRefreshControl class]])
         return [CKRefreshControl appearance];


### PR DESCRIPTION
XCode 5 syntax checking is displaying a new warning on lines 391 and 416 of CKRefreshControl.m 

"Incompatible pointer types returning 'UIRefreshControl *' from a function with result type 'CKRefreshControl *'"

solved this by typecasting 'UIRefreshControl *' as 'id' in +appearance and +appearanceWhenContainedIn: class methods ... 

Xcode 5 no longer displays the warning
